### PR TITLE
Canvas - fix initialisation

### DIFF
--- a/sugargame/canvas.py
+++ b/sugargame/canvas.py
@@ -1,6 +1,5 @@
 import os
 from gi.repository import Gtk
-from gi.repository import GObject
 from gi.repository import GLib
 from sugar3.activity.activity import PREVIEW_SIZE
 import pygame
@@ -12,7 +11,7 @@ CANVAS = None
 class PygameCanvas(Gtk.EventBox):
     def __init__(self, activity, pointer_hint=True,
                  main=None, modules=[pygame]):
-        GObject.GObject.__init__(self)
+        Gtk.EventBox.__init__(self)
 
         global CANVAS
         assert CANVAS == None, "Only one PygameCanvas can be created, ever."

--- a/sugargame/event.py
+++ b/sugargame/event.py
@@ -1,6 +1,6 @@
 import logging
+from gi.repository import GLib
 from gi.repository import Gdk
-from gi.repository import GObject
 import pygame
 import pygame.event
 
@@ -237,9 +237,9 @@ class Translator(object):
 
     def _set_repeat(self, delay=None, interval=None):
         if delay is not None and self.__repeat[0] is None:
-            self.__tick_id = GObject.timeout_add(10, self._tick_cb)
+            self.__tick_id = GLib.timeout_add(10, self._tick_cb)
         elif delay is None and self.__repeat[0] is not None:
-            GObject.source_remove(self.__tick_id)
+            GLib.source_remove(self.__tick_id)
         self.__repeat = (delay, interval)
 
     def _get_mouse_pos(self):


### PR DESCRIPTION
Parent class was not initialised.  No apparent impact.

Port from GObject to GLib.  Fixes https://github.com/sugarlabs/sugargame/issues/3.

@yashagrawal3, please review.