### PR TITLE
Fix _get_pressed() returning list of booleans

### DIFF
--- a/sugargame/event.py
+++ b/sugargame/event.py
@@ -338,7 +338,7 @@ class Translator(object):
         return True
 
     def _get_pressed(self):
-        return list(self.__keystate.values())
+        return self.__keystate
 
     def _get_mouse_pressed(self):
         return self.__button_state


### PR DESCRIPTION
The changes commited in e4d3122 converted the type of self.__keystate from bool array into dict(int: bool). However, _get_pressed() still returns a list of 134 booleans. Checking key presses for a key such as pygame.K_RIGHT(1073741903) would go past the size of the list resulting in an IndexError.

* return self.__keystate dict from _get_pressed() instead of it's values.

Solves the issue encountered in https://github.com/sugarlabs/ball-and-brick-activity/pull/24#issuecomment-2053740586.

@quozl, @walterbender, @chimosky please review.